### PR TITLE
feat: Add ember-resources integration via resource factories

### DIFF
--- a/docs/fetching/resource-factories.md
+++ b/docs/fetching/resource-factories.md
@@ -22,53 +22,15 @@ pnpm add ember-resources
 npm install ember-resources
 ```
 
-## Template-Only Usage
+## Curried Resource Factories
 
-The primary motivation for resource factories is enabling Apollo queries directly in templates using `{{#let}}`.
+The recommended way to use resource factories in templates is via **curried factories**. Call `createQueryResource` / `createMutationResource` / `createSubscriptionResource` with a GraphQL document to get a reusable resource that can be invoked in templates or with `@use`:
 
-### queryResource in templates
-
-Pass the query document and an options hash directly to `queryResource`:
-
-```gts:notes.gts
-import { gql } from 'glimmer-apollo';
-import { queryResource } from 'glimmer-apollo/resource-factories';
-
-const GET_NOTES = gql`
-  query GetNotes {
-    notes {
-      id
-      title
-      description
-    }
-  }
-`;
-
-<template>
-  {{#let (queryResource GET_NOTES) as |notes|}}
-    {{#if notes.loading}}
-      Loading...
-    {{else if notes.error}}
-      Error!: {{notes.error.message}}
-    {{else}}
-      {{#each notes.data.notes as |note|}}
-        <div>
-          Title: {{note.title}}
-          Description: {{note.description}}
-        </div>
-      {{/each}}
-    {{/if}}
-  {{/let}}
-</template>
-```
-
-### Passing variables with the hash helper
-
-Use `(hash ...)` to pass variables and options:
+### createQueryResource in templates
 
 ```gts:user-profile.gts
 import { gql } from 'glimmer-apollo';
-import { queryResource } from 'glimmer-apollo/resource-factories';
+import { createQueryResource } from 'glimmer-apollo/resource-factories';
 
 const GET_USER = gql`
   query GetUser($id: ID!) {
@@ -80,8 +42,10 @@ const GET_USER = gql`
   }
 `;
 
+const getUser = createQueryResource(GET_USER);
+
 <template>
-  {{#let (queryResource GET_USER (hash variables=(hash id=@userId))) as |user|}}
+  {{#let (getUser (hash variables=(hash id=@userId))) as |user|}}
     {{#if user.loading}}
       Loading...
     {{else if user.error}}
@@ -95,13 +59,13 @@ const GET_USER = gql`
 
 When `@userId` changes, the resource is re-created with the new variables.
 
-### mutationResource in templates
+### createMutationResource in templates
 
 ```gts:create-note.gts
 import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
 import { gql } from 'glimmer-apollo';
-import { mutationResource } from 'glimmer-apollo/resource-factories';
+import { createMutationResource } from 'glimmer-apollo/resource-factories';
 
 const CREATE_NOTE = gql`
   mutation CreateNote($input: NoteInput!) {
@@ -112,26 +76,28 @@ const CREATE_NOTE = gql`
   }
 `;
 
+const createNote = createMutationResource(CREATE_NOTE);
+
 <template>
-  {{#let (mutationResource CREATE_NOTE) as |createNote|}}
-    <button {{on "click" (fn createNote.mutate (hash input=(hash title="New Note")))}}>
+  {{#let (createNote) as |mutation|}}
+    <button {{on "click" (fn mutation.mutate (hash input=(hash title="New Note")))}}>
       Create Note
     </button>
 
-    {{#if createNote.loading}}
+    {{#if mutation.loading}}
       Creating...
-    {{else if createNote.called}}
-      Created: {{createNote.data.createNote.title}}
+    {{else if mutation.called}}
+      Created: {{mutation.data.createNote.title}}
     {{/if}}
   {{/let}}
 </template>
 ```
 
-### subscriptionResource in templates
+### createSubscriptionResource in templates
 
 ```gts:latest-message.gts
 import { gql } from 'glimmer-apollo';
-import { subscriptionResource } from 'glimmer-apollo/resource-factories';
+import { createSubscriptionResource } from 'glimmer-apollo/resource-factories';
 
 const ON_MESSAGE_ADDED = gql`
   subscription OnMessageAdded($channel: String!) {
@@ -142,8 +108,10 @@ const ON_MESSAGE_ADDED = gql`
   }
 `;
 
+const onMessageAdded = createSubscriptionResource(ON_MESSAGE_ADDED);
+
 <template>
-  {{#let (subscriptionResource ON_MESSAGE_ADDED (hash variables=(hash channel="general"))) as |sub|}}
+  {{#let (onMessageAdded (hash variables=(hash channel="general"))) as |sub|}}
     {{#if sub.loading}}
       Connecting...
     {{else if sub.error}}
@@ -157,7 +125,7 @@ const ON_MESSAGE_ADDED = gql`
 
 ## Usage with @use decorator
 
-Resource factories also work with the `@use` decorator from `ember-resources` in class-based components. Pass a thunk function for reactive tracked dependencies:
+Curried resource factories work with the `@use` decorator from `ember-resources` in class-based components. Pass a thunk returning options for reactive tracked dependencies:
 
 ```gts:notes.gts
 import Component from '@glimmer/component';
@@ -166,7 +134,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { use } from 'ember-resources';
 import { gql } from 'glimmer-apollo';
-import { queryResource } from 'glimmer-apollo/resource-factories';
+import { createQueryResource } from 'glimmer-apollo/resource-factories';
 
 const GET_NOTES = gql`
   query GetNotes($isArchived: Boolean) {
@@ -178,13 +146,14 @@ const GET_NOTES = gql`
   }
 `;
 
+const getNotes = createQueryResource(GET_NOTES);
+
 export default class Notes extends Component {
   @tracked isArchived = false;
 
-  @use notes = queryResource(() => [
-    GET_NOTES,
-    { variables: { isArchived: this.isArchived } }
-  ]);
+  @use notes = getNotes(() => ({
+    variables: { isArchived: this.isArchived }
+  }));
 
   @action
   toggleIsArchived(): void {
@@ -224,7 +193,7 @@ import { on } from '@ember/modifier';
 import { action } from '@ember/object';
 import { use } from 'ember-resources';
 import { gql } from 'glimmer-apollo';
-import { mutationResource } from 'glimmer-apollo/resource-factories';
+import { createMutationResource } from 'glimmer-apollo/resource-factories';
 
 const CREATE_NOTE = gql`
   mutation CreateNote($input: NoteInput!) {
@@ -236,12 +205,14 @@ const CREATE_NOTE = gql`
   }
 `;
 
+const createNote = createMutationResource(CREATE_NOTE);
+
 export default class CreateNote extends Component {
-  @use createNote = mutationResource(() => [CREATE_NOTE]);
+  @use createNoteMutation = createNote();
 
   @action
   async submit(): Promise<void> {
-    await this.createNote.mutate({
+    await this.createNoteMutation.mutate({
       input: {
         title: 'Title',
         description: 'Description',
@@ -255,18 +226,24 @@ export default class CreateNote extends Component {
       Create Note
     </button>
 
-    {{#if this.createNote.loading}}
+    {{#if this.createNoteMutation.loading}}
       Creating...
-    {{else if this.createNote.error}}
-      Error!: {{this.createNote.error.message}}
-    {{else if this.createNote.called}}
+    {{else if this.createNoteMutation.error}}
+      Error!: {{this.createNoteMutation.error.message}}
+    {{else if this.createNoteMutation.called}}
       <div>
-        id: {{this.createNote.data.createNote.id}}
-        Title: {{this.createNote.data.createNote.title}}
+        id: {{this.createNoteMutation.data.createNote.id}}
+        Title: {{this.createNoteMutation.data.createNote.title}}
       </div>
     {{/if}}
   </template>
 }
+```
+
+You can also use the base `queryResource`/`mutationResource`/`subscriptionResource` directly with `@use` by passing a thunk that returns `[document, options]`:
+
+```ts
+@use notes = queryResource(() => [GET_NOTES, { variables: { isArchived: this.isArchived } }]);
 ```
 
 ## Available features
@@ -293,11 +270,19 @@ All resource factories expose the same properties and methods as their `use*` co
 
 ## Calling conventions
 
-Each factory accepts two calling conventions:
+| Function | Syntax | Use case |
+|----------|--------|----------|
+| `queryResource` | `queryResource(() => [QUERY, options])` | `@use` decorator with tracked reactivity |
+| `createQueryResource` | `const q = createQueryResource(QUERY)` | Curried factory for templates and `@use` |
 
-| Convention | Syntax | Use case |
-|-----------|--------|----------|
-| Direct args | `queryResource(QUERY, options)` | Template invocation with `{{#let}}` |
-| Thunk | `queryResource(() => [QUERY, options])` | `@use` decorator with tracked reactivity |
+Curried factories accept both thunks (for `@use` reactivity) and direct options (for template invocation):
 
-Both use the same underlying Resource classes as `useQuery`/`useMutation`/`useSubscription`.
+```ts
+// @use with thunk — tracks reactive dependencies
+@use query = getUser(() => ({ variables: { id: this.userId } }));
+
+// Template with direct options
+{{#let (getUser (hash variables=(hash id="1"))) as |q|}} ... {{/let}}
+```
+
+All factories use the same underlying Resource classes as `useQuery`/`useMutation`/`useSubscription`.

--- a/docs/fetching/resource-factories.md
+++ b/docs/fetching/resource-factories.md
@@ -1,0 +1,303 @@
+---
+order: 4
+---
+
+# Resource Factories
+
+Resource factories let you use Apollo queries, mutations, and subscriptions directly in templates — including template-only components — without needing a backing class. They integrate with `ember-resources` and also support the `@use` decorator and composability.
+
+The existing `useQuery`, `useMutation`, and `useSubscription` functions continue to work unchanged. Resource factories are additive.
+
+## Prerequisites
+
+`ember-resources` is an optional peer dependency of `glimmer-apollo`. Importing from `glimmer-apollo/resource-factories` **requires `ember-resources` to be installed** — the import will fail at runtime if the package is not present. The main `glimmer-apollo` import is unaffected and continues to work without `ember-resources`.
+
+Install `ember-resources` as a dependency of your app:
+
+```sh
+pnpm add ember-resources
+```
+
+```sh
+npm install ember-resources
+```
+
+## Template-Only Usage
+
+The primary motivation for resource factories is enabling Apollo queries directly in templates using `{{#let}}`.
+
+### queryResource in templates
+
+Pass the query document and an options hash directly to `queryResource`:
+
+```gts:notes.gts
+import { gql } from 'glimmer-apollo';
+import { queryResource } from 'glimmer-apollo/resource-factories';
+
+const GET_NOTES = gql`
+  query GetNotes {
+    notes {
+      id
+      title
+      description
+    }
+  }
+`;
+
+<template>
+  {{#let (queryResource GET_NOTES) as |notes|}}
+    {{#if notes.loading}}
+      Loading...
+    {{else if notes.error}}
+      Error!: {{notes.error.message}}
+    {{else}}
+      {{#each notes.data.notes as |note|}}
+        <div>
+          Title: {{note.title}}
+          Description: {{note.description}}
+        </div>
+      {{/each}}
+    {{/if}}
+  {{/let}}
+</template>
+```
+
+### Passing variables with the hash helper
+
+Use `(hash ...)` to pass variables and options:
+
+```gts:user-profile.gts
+import { gql } from 'glimmer-apollo';
+import { queryResource } from 'glimmer-apollo/resource-factories';
+
+const GET_USER = gql`
+  query GetUser($id: ID!) {
+    user(id: $id) {
+      id
+      firstName
+      lastName
+    }
+  }
+`;
+
+<template>
+  {{#let (queryResource GET_USER (hash variables=(hash id=@userId))) as |user|}}
+    {{#if user.loading}}
+      Loading...
+    {{else if user.error}}
+      Error!: {{user.error.message}}
+    {{else}}
+      <h1>{{user.data.user.firstName}} {{user.data.user.lastName}}</h1>
+    {{/if}}
+  {{/let}}
+</template>
+```
+
+When `@userId` changes, the resource is re-created with the new variables.
+
+### mutationResource in templates
+
+```gts:create-note.gts
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+import { gql } from 'glimmer-apollo';
+import { mutationResource } from 'glimmer-apollo/resource-factories';
+
+const CREATE_NOTE = gql`
+  mutation CreateNote($input: NoteInput!) {
+    createNote(input: $input) {
+      id
+      title
+    }
+  }
+`;
+
+<template>
+  {{#let (mutationResource CREATE_NOTE) as |createNote|}}
+    <button {{on "click" (fn createNote.mutate (hash input=(hash title="New Note")))}}>
+      Create Note
+    </button>
+
+    {{#if createNote.loading}}
+      Creating...
+    {{else if createNote.called}}
+      Created: {{createNote.data.createNote.title}}
+    {{/if}}
+  {{/let}}
+</template>
+```
+
+### subscriptionResource in templates
+
+```gts:latest-message.gts
+import { gql } from 'glimmer-apollo';
+import { subscriptionResource } from 'glimmer-apollo/resource-factories';
+
+const ON_MESSAGE_ADDED = gql`
+  subscription OnMessageAdded($channel: String!) {
+    messageAdded(channel: $channel) {
+      id
+      message
+    }
+  }
+`;
+
+<template>
+  {{#let (subscriptionResource ON_MESSAGE_ADDED (hash variables=(hash channel="general"))) as |sub|}}
+    {{#if sub.loading}}
+      Connecting...
+    {{else if sub.error}}
+      Error!: {{sub.error.message}}
+    {{else}}
+      New Message: {{sub.data.messageAdded.message}}
+    {{/if}}
+  {{/let}}
+</template>
+```
+
+## Usage with @use decorator
+
+Resource factories also work with the `@use` decorator from `ember-resources` in class-based components. Pass a thunk function for reactive tracked dependencies:
+
+```gts:notes.gts
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { use } from 'ember-resources';
+import { gql } from 'glimmer-apollo';
+import { queryResource } from 'glimmer-apollo/resource-factories';
+
+const GET_NOTES = gql`
+  query GetNotes($isArchived: Boolean) {
+    notes(isArchived: $isArchived) {
+      id
+      title
+      description
+    }
+  }
+`;
+
+export default class Notes extends Component {
+  @tracked isArchived = false;
+
+  @use notes = queryResource(() => [
+    GET_NOTES,
+    { variables: { isArchived: this.isArchived } }
+  ]);
+
+  @action
+  toggleIsArchived(): void {
+    this.isArchived = !this.isArchived;
+  }
+
+  <template>
+    <button {{on "click" this.toggleIsArchived}}>
+      {{#if this.isArchived}}Show not archived{{else}}Show archived{{/if}}
+    </button>
+
+    {{#if this.notes.loading}}
+      Loading...
+    {{else if this.notes.error}}
+      Error!: {{this.notes.error.message}}
+    {{else}}
+      {{#each this.notes.data.notes as |note|}}
+        <div>
+          Title: {{note.title}}
+          Description: {{note.description}}
+        </div>
+      {{/each}}
+    {{/if}}
+  </template>
+}
+```
+
+Notice there is no `this` argument — the `@use` decorator handles context and destruction automatically.
+
+When `this.isArchived` changes, the query automatically re-executes with the updated variables. Values are compared using deep equality (`@wry/equality`), so setting a tracked property to the same value does not trigger a re-fetch.
+
+### mutationResource with @use
+
+```gts:create-note.gts
+import Component from '@glimmer/component';
+import { on } from '@ember/modifier';
+import { action } from '@ember/object';
+import { use } from 'ember-resources';
+import { gql } from 'glimmer-apollo';
+import { mutationResource } from 'glimmer-apollo/resource-factories';
+
+const CREATE_NOTE = gql`
+  mutation CreateNote($input: NoteInput!) {
+    createNote(input: $input) {
+      id
+      title
+      description
+    }
+  }
+`;
+
+export default class CreateNote extends Component {
+  @use createNote = mutationResource(() => [CREATE_NOTE]);
+
+  @action
+  async submit(): Promise<void> {
+    await this.createNote.mutate({
+      input: {
+        title: 'Title',
+        description: 'Description',
+        isArchived: false
+      }
+    });
+  }
+
+  <template>
+    <button {{on "click" this.submit}}>
+      Create Note
+    </button>
+
+    {{#if this.createNote.loading}}
+      Creating...
+    {{else if this.createNote.error}}
+      Error!: {{this.createNote.error.message}}
+    {{else if this.createNote.called}}
+      <div>
+        id: {{this.createNote.data.createNote.id}}
+        Title: {{this.createNote.data.createNote.title}}
+      </div>
+    {{/if}}
+  </template>
+}
+```
+
+## Available features
+
+All resource factories expose the same properties and methods as their `use*` counterparts:
+
+### queryResource
+
+- **Status**: `loading`, `error`, `data`, `networkStatus`, `promise`
+- **Methods**: `refetch()`, `fetchMore()`, `updateQuery()`, `startPolling()`, `stopPolling()`, `subscribeToMore()`, `settled()`
+- **Options**: `variables`, `fetchPolicy`, `errorPolicy`, `skip`, `ssr`, `clientId`, `onComplete`, `onError`
+
+### mutationResource
+
+- **Status**: `loading`, `called`, `error`, `data`, `promise`
+- **Methods**: `mutate(variables?, options?)`, `settled()`
+- **Options**: `variables`, `errorPolicy`, `clientId`, `onComplete`, `onError`
+
+### subscriptionResource
+
+- **Status**: `loading`, `error`, `data`, `promise`
+- **Methods**: `settled()`
+- **Options**: `variables`, `errorPolicy`, `ssr`, `clientId`, `onData`, `onError`, `onComplete`
+
+## Calling conventions
+
+Each factory accepts two calling conventions:
+
+| Convention | Syntax | Use case |
+|-----------|--------|----------|
+| Direct args | `queryResource(QUERY, options)` | Template invocation with `{{#let}}` |
+| Thunk | `queryResource(() => [QUERY, options])` | `@use` decorator with tracked reactivity |
+
+Both use the same underlying Resource classes as `useQuery`/`useMutation`/`useSubscription`.

--- a/glimmer-apollo/package.json
+++ b/glimmer-apollo/package.json
@@ -13,6 +13,10 @@
       "types": "./declarations/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./resource-factories": {
+      "types": "./declarations/resource-factories.d.ts",
+      "default": "./dist/resource-factories.js"
+    },
     "./*": {
       "types": "./declarations/*.d.ts",
       "default": "./dist/*.js"
@@ -82,7 +86,13 @@
   },
   "peerDependencies": {
     "@apollo/client": "^4.0.0",
+    "ember-resources": "^7.0.0",
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ember-resources": {
+      "optional": true
+    }
   },
   "ember": {
     "edition": "octane"

--- a/glimmer-apollo/rollup.config.mjs
+++ b/glimmer-apollo/rollup.config.mjs
@@ -20,7 +20,12 @@ export default {
     // up your addon's public API. Also make sure your package.json#exports
     // is aligned to the config here.
     // See https://github.com/embroider-build/embroider/blob/main/docs/v2-faq.md#how-can-i-define-the-public-exports-of-my-addon
-    addon.publicEntrypoints(['**/*.js', 'index.js', 'template-registry.js']),
+    addon.publicEntrypoints([
+      '**/*.js',
+      'index.js',
+      'resource-factories.js',
+      'template-registry.js',
+    ]),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but

--- a/glimmer-apollo/src/-private/resource-factories.ts
+++ b/glimmer-apollo/src/-private/resource-factories.ts
@@ -123,66 +123,128 @@ function wrapResource<
   });
 }
 
-// queryResource accepts either:
-//   - A thunk: queryResource(() => [QUERY, options])    — for @use decorator
-//   - Direct args: queryResource(QUERY, options)        — for template invocation
 export function queryResource<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
->(
-  thunkOrDoc: (() => QueryPositionalArgs<TData, TVariables>) | DocumentNode,
-  options?: QueryOptions<TData, TVariables>,
-) {
-  const thunk: () => QueryPositionalArgs<TData, TVariables> =
-    typeof thunkOrDoc === 'function'
-      ? thunkOrDoc
-      : () => [thunkOrDoc, options] as QueryPositionalArgs<TData, TVariables>;
-
+>(thunk: () => QueryPositionalArgs<TData, TVariables>) {
   return wrapResource(QueryResource, thunk);
 }
 resourceFactory(queryResource);
 
-// mutationResource accepts either:
-//   - A thunk: mutationResource(() => [MUTATION, options])    — for @use decorator
-//   - Direct args: mutationResource(MUTATION, options)        — for template invocation
 export function mutationResource<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
->(
-  thunkOrDoc: (() => MutationPositionalArgs<TData, TVariables>) | DocumentNode,
-  options?: MutationOptions<TData, TVariables>,
-) {
-  const thunk: () => MutationPositionalArgs<TData, TVariables> =
-    typeof thunkOrDoc === 'function'
-      ? thunkOrDoc
-      : () =>
-          [thunkOrDoc, options] as MutationPositionalArgs<TData, TVariables>;
-
+>(thunk: () => MutationPositionalArgs<TData, TVariables>) {
   return wrapResource(MutationResource, thunk);
 }
 resourceFactory(mutationResource);
 
-// subscriptionResource accepts either:
-//   - A thunk: subscriptionResource(() => [SUB, options])    — for @use decorator
-//   - Direct args: subscriptionResource(SUB, options)        — for template invocation
 export function subscriptionResource<
   TData = unknown,
   TVariables extends OperationVariables = OperationVariables,
->(
-  thunkOrDoc:
-    | (() => SubscriptionPositionalArgs<TData, TVariables>)
-    | DocumentNode,
-  options?: SubscriptionOptions<TData, TVariables>,
-) {
-  const thunk: () => SubscriptionPositionalArgs<TData, TVariables> =
-    typeof thunkOrDoc === 'function'
-      ? thunkOrDoc
-      : () =>
-          [thunkOrDoc, options] as SubscriptionPositionalArgs<
-            TData,
-            TVariables
-          >;
-
+>(thunk: () => SubscriptionPositionalArgs<TData, TVariables>) {
   return wrapResource(SubscriptionResource, thunk);
 }
 resourceFactory(subscriptionResource);
+
+/**
+ * Create a curried query resource factory. Call with a document to get a
+ * reusable resource that accepts options (or a thunk returning options).
+ *
+ * ```ts
+ * const userInfo = createQueryResource<UserInfoQuery, UserInfoQueryVariables>(USER_INFO);
+ *
+ * // In a class with @use:
+ * @use query = userInfo(() => ({ variables: { id: '1' } }));
+ *
+ * // In a template:
+ * {{#let (userInfo (hash variables=(hash id="1"))) as |q|}} ... {{/let}}
+ * ```
+ */
+export function createQueryResource<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables,
+>(document: DocumentNode) {
+  function inner(
+    thunkOrOptions?:
+      | (() => QueryOptions<TData, TVariables> | undefined)
+      | QueryOptions<TData, TVariables>,
+  ) {
+    const optionsThunk =
+      typeof thunkOrOptions === 'function'
+        ? thunkOrOptions
+        : () => thunkOrOptions;
+    return queryResource<TData, TVariables>(() => [document, optionsThunk()]);
+  }
+  resourceFactory(inner);
+  return inner;
+}
+
+/**
+ * Create a curried mutation resource factory. Call with a document to get a
+ * reusable resource that accepts options (or a thunk returning options).
+ *
+ * ```ts
+ * const login = createMutationResource<LoginMutation, LoginMutationVariables>(LOGIN);
+ *
+ * // In a class with @use:
+ * @use mutation = login(() => ({ variables: { username: 'john' } }));
+ * ```
+ */
+export function createMutationResource<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables,
+>(document: DocumentNode) {
+  function inner(
+    thunkOrOptions?:
+      | (() => MutationOptions<TData, TVariables> | undefined)
+      | MutationOptions<TData, TVariables>,
+  ) {
+    const optionsThunk =
+      typeof thunkOrOptions === 'function'
+        ? thunkOrOptions
+        : () => thunkOrOptions;
+    return mutationResource<TData, TVariables>(() => [
+      document,
+      optionsThunk(),
+    ]);
+  }
+  resourceFactory(inner);
+  return inner;
+}
+
+/**
+ * Create a curried subscription resource factory. Call with a document to get a
+ * reusable resource that accepts options (or a thunk returning options).
+ *
+ * ```ts
+ * const onMessage = createSubscriptionResource<OnMessageSubscription, OnMessageSubscriptionVariables>(ON_MESSAGE);
+ *
+ * // In a class with @use:
+ * @use sub = onMessage(() => ({ variables: { channel: 'general' } }));
+ *
+ * // In a template:
+ * {{#let (onMessage (hash variables=(hash channel="general"))) as |s|}} ... {{/let}}
+ * ```
+ */
+export function createSubscriptionResource<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables,
+>(document: DocumentNode) {
+  function inner(
+    thunkOrOptions?:
+      | (() => SubscriptionOptions<TData, TVariables> | undefined)
+      | SubscriptionOptions<TData, TVariables>,
+  ) {
+    const optionsThunk =
+      typeof thunkOrOptions === 'function'
+        ? thunkOrOptions
+        : () => thunkOrOptions;
+    return subscriptionResource<TData, TVariables>(() => [
+      document,
+      optionsThunk(),
+    ]);
+  }
+  resourceFactory(inner);
+  return inner;
+}

--- a/glimmer-apollo/src/-private/resource-factories.ts
+++ b/glimmer-apollo/src/-private/resource-factories.ts
@@ -1,0 +1,188 @@
+// Requires ember-resources >= 7.0 (optional peerDependency).
+import { resource, resourceFactory } from 'ember-resources';
+import { createCache, getValue, destroy } from '../environment.ts';
+import {
+  QueryResource,
+  type QueryPositionalArgs,
+  type QueryOptions,
+} from './query.ts';
+import {
+  MutationResource,
+  type MutationPositionalArgs,
+  type MutationOptions,
+} from './mutation.ts';
+import {
+  SubscriptionResource,
+  type SubscriptionPositionalArgs,
+  type SubscriptionOptions,
+} from './subscription.ts';
+import { Resource } from './resource.ts';
+import type { DocumentNode, OperationVariables } from '@apollo/client';
+import type { TemplateArgs } from './types.ts';
+import type Owner from '@ember/owner';
+
+/**
+ * Shared helper that wraps any Resource subclass into an ember-resources
+ * `resource()` function. Lifecycle introspection (update / teardown) is
+ * derived from the prototype, mirroring ResourceManager.createHelper in
+ * resource.ts (lines 87-90).
+ */
+function wrapResource<
+  TInstance extends Resource<TemplateArgs<readonly unknown[]>>,
+  TPositionalArgs extends readonly unknown[],
+>(
+  ResourceClass: new (
+    owner: Owner,
+    args: TemplateArgs<TPositionalArgs>,
+  ) => TInstance,
+  thunk: () => TPositionalArgs,
+) {
+  return resource(({ on, owner }) => {
+    const args: TemplateArgs<TPositionalArgs> = {
+      get positional() {
+        return thunk();
+      },
+      // named is intentionally empty: all config is passed via positional
+      // args as [DocumentNode, Options?], matching the Resource contract.
+      named: {},
+    };
+
+    const instance = new ResourceClass(owner, args);
+
+    // Introspect lifecycle methods from the prototype, mirroring
+    // ResourceManager.createHelper in resource.ts (lines 87-90).
+    // MutationResource has no update/teardown, so these are false for it.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const proto: Resource<TemplateArgs<TPositionalArgs>> =
+      ResourceClass.prototype;
+    const hasUpdate = typeof proto.update === 'function';
+    const hasTeardown = typeof proto.teardown === 'function';
+
+    on.cleanup(() => {
+      if (hasTeardown) instance.teardown!();
+      destroy(instance);
+    });
+
+    let updateCache: ReturnType<typeof createCache> | undefined;
+    if (hasUpdate) {
+      // For resources with update (Query, Subscription): setup() and
+      // update() are called inside a createCache so their tracked reads
+      // (thunk → tracked args) are entangled with this inner cache ONLY.
+      //
+      // IMPORTANT: We do NOT call getValue(updateCache) eagerly here.
+      // Calling it in the resource() callback would leak tracked reads
+      // into the outer ember-resources tracking frame, causing the
+      // entire resource to be re-created when args change (instead of
+      // just calling update()). Setup happens lazily on first property
+      // access through the Proxy — consistent with how useResource
+      // lazily invokes the helper on first .value access.
+      let isSetUp = false;
+      updateCache = createCache(() => {
+        if (!isSetUp) {
+          instance.setup();
+          isSetUp = true;
+        } else {
+          instance.update!();
+        }
+        return instance;
+      });
+    } else {
+      // Resources without update (e.g. MutationResource): call setup()
+      // directly. ResourceManager.createHelper always calls setupInstance
+      // for every resource type, so we do the same for forward compat.
+      instance.setup();
+    }
+
+    return new Proxy(instance, {
+      get(target, key) {
+        // Skip Symbols to avoid spurious cache evaluations.
+        if (updateCache && typeof key === 'string') {
+          getValue(updateCache);
+        }
+        // .bind(target) is required: private fields (#field) have a brand check
+        // that fails if `this` is the proxy instead of the real instance.
+        const value = Reflect.get(target, key, target);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+      // Keep ownKeys/getOwnPropertyDescriptor for consistency
+      // with useResource in use-resource.ts (lines 68-73).
+      ownKeys(target) {
+        if (updateCache) {
+          getValue(updateCache);
+        }
+        return Reflect.ownKeys(target);
+      },
+      getOwnPropertyDescriptor(target, key) {
+        if (updateCache) {
+          getValue(updateCache);
+        }
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+    });
+  });
+}
+
+// queryResource accepts either:
+//   - A thunk: queryResource(() => [QUERY, options])    — for @use decorator
+//   - Direct args: queryResource(QUERY, options)        — for template invocation
+export function queryResource<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables,
+>(
+  thunkOrDoc: (() => QueryPositionalArgs<TData, TVariables>) | DocumentNode,
+  options?: QueryOptions<TData, TVariables>,
+) {
+  const thunk: () => QueryPositionalArgs<TData, TVariables> =
+    typeof thunkOrDoc === 'function'
+      ? thunkOrDoc
+      : () => [thunkOrDoc, options] as QueryPositionalArgs<TData, TVariables>;
+
+  return wrapResource(QueryResource, thunk);
+}
+resourceFactory(queryResource);
+
+// mutationResource accepts either:
+//   - A thunk: mutationResource(() => [MUTATION, options])    — for @use decorator
+//   - Direct args: mutationResource(MUTATION, options)        — for template invocation
+export function mutationResource<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables,
+>(
+  thunkOrDoc: (() => MutationPositionalArgs<TData, TVariables>) | DocumentNode,
+  options?: MutationOptions<TData, TVariables>,
+) {
+  const thunk: () => MutationPositionalArgs<TData, TVariables> =
+    typeof thunkOrDoc === 'function'
+      ? thunkOrDoc
+      : () =>
+          [thunkOrDoc, options] as MutationPositionalArgs<TData, TVariables>;
+
+  return wrapResource(MutationResource, thunk);
+}
+resourceFactory(mutationResource);
+
+// subscriptionResource accepts either:
+//   - A thunk: subscriptionResource(() => [SUB, options])    — for @use decorator
+//   - Direct args: subscriptionResource(SUB, options)        — for template invocation
+export function subscriptionResource<
+  TData = unknown,
+  TVariables extends OperationVariables = OperationVariables,
+>(
+  thunkOrDoc:
+    | (() => SubscriptionPositionalArgs<TData, TVariables>)
+    | DocumentNode,
+  options?: SubscriptionOptions<TData, TVariables>,
+) {
+  const thunk: () => SubscriptionPositionalArgs<TData, TVariables> =
+    typeof thunkOrDoc === 'function'
+      ? thunkOrDoc
+      : () =>
+          [thunkOrDoc, options] as SubscriptionPositionalArgs<
+            TData,
+            TVariables
+          >;
+
+  return wrapResource(SubscriptionResource, thunk);
+}
+resourceFactory(subscriptionResource);

--- a/glimmer-apollo/src/resource-factories.ts
+++ b/glimmer-apollo/src/resource-factories.ts
@@ -5,4 +5,7 @@ export {
   queryResource,
   mutationResource,
   subscriptionResource,
+  createQueryResource,
+  createMutationResource,
+  createSubscriptionResource,
 } from './-private/resource-factories.ts';

--- a/glimmer-apollo/src/resource-factories.ts
+++ b/glimmer-apollo/src/resource-factories.ts
@@ -1,0 +1,8 @@
+// This module requires ember-resources >= 7.0 to be installed.
+// It will fail at runtime if ember-resources is not present.
+// The main 'glimmer-apollo' import is unaffected.
+export {
+  queryResource,
+  mutationResource,
+  subscriptionResource,
+} from './-private/resource-factories.ts';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       decorator-transforms:
         specifier: ^2.2.2
         version: 2.3.0(@babel/core@7.28.5)
+      ember-resources:
+        specifier: ^7.0.0
+        version: 7.0.7(@glimmer/component@2.0.0)(@glint/template@1.7.3)
       graphql:
         specifier: ^14.0.0 || ^15.0.0 || ^16.0.0
         version: 16.12.0
@@ -409,6 +412,9 @@ importers:
       ember-resolver:
         specifier: ^13.1.1
         version: 13.1.1
+      ember-resources:
+        specifier: ^7.0.0
+        version: 7.0.7(@glimmer/component@2.0.0)(@glint/template@1.7.3)
       ember-route-template:
         specifier: ^1.0.3
         version: 1.0.3

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -63,6 +63,7 @@
     "ember-load-initializers": "^3.0.1",
     "ember-modifier": "^4.2.2",
     "ember-page-title": "^9.0.3",
+    "ember-resources": "^7.0.0",
     "ember-qunit": "^9.0.4",
     "ember-resolver": "^13.1.1",
     "ember-route-template": "^1.0.3",

--- a/test-app/tests/integration/components/resource-factory-test.gts
+++ b/test-app/tests/integration/components/resource-factory-test.gts
@@ -11,6 +11,9 @@ import {
   queryResource,
   mutationResource,
   subscriptionResource,
+  createQueryResource,
+  createMutationResource,
+  createSubscriptionResource,
 } from 'glimmer-apollo/resource-factories';
 import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client';
 import { MockSubscriptionLink } from 'test-app/tests/helpers/mock-subscription-link';
@@ -152,55 +155,6 @@ module('Integration | Components | Resource Factories', function (hooks) {
     assert
       .dom('[data-test-id="error"]')
       .hasText('User not found', 'renders error message');
-  });
-
-  test('queryResource works in template-only component with direct args', async function (assert) {
-    const options = { variables: { id: '1' } };
-
-    await render(
-      <template>
-        {{#let (queryResource USER_INFO options) as |query|}}
-          <div data-test-id="template-only">
-            {{#if query.loading}}
-              <span data-test-id="loading">Loading...</span>
-            {{else if query.error}}
-              <span data-test-id="error">{{query.error.message}}</span>
-            {{else}}
-              <span data-test-id="data">{{query.data.user.firstName}}</span>
-            {{/if}}
-          </div>
-        {{/let}}
-      </template>
-    );
-
-    assert
-      .dom('[data-test-id="data"]')
-      .hasText('Cathaline', 'renders fetched data in template-only component');
-  });
-
-  test('queryResource works in template-only component with hash helper', async function (assert) {
-    await render(
-      <template>
-        {{#let
-          (queryResource USER_INFO (hash variables=(hash id="2")))
-          as |query|
-        }}
-          <div data-test-id="hash-test">
-            {{#if query.loading}}
-              <span data-test-id="loading">Loading...</span>
-            {{else if query.error}}
-              <span data-test-id="error">{{query.error.message}}</span>
-            {{else}}
-              <span data-test-id="data">{{query.data.user.firstName}}</span>
-            {{/if}}
-          </div>
-        {{/let}}
-      </template>
-    );
-
-    assert
-      .dom('[data-test-id="data"]')
-      .hasText('Joth', 'renders user 2 data with hash helper');
   });
 
   test('mutationResource works in template with click handler', async function (assert) {
@@ -394,6 +348,220 @@ module(
       assert
         .dom('[data-test-id="message"]')
         .hasText('Second Message', 'renders updated subscription message');
+    });
+  }
+);
+
+// Curried resource factory tests
+
+const userInfo = createQueryResource<UserInfoQuery, UserInfoQueryVariables>(
+  USER_INFO
+);
+const loginMutation = createMutationResource<
+  LoginMutation,
+  LoginMutationVariables
+>(LOGIN);
+
+module(
+  'Integration | Components | Curried Resource Factories',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link: new HttpLink({ uri: '/graphql' }),
+      });
+      setClient(this.owner, client);
+    });
+
+    test('createQueryResource with @use and thunk options', async function (assert) {
+      class TestComponent extends Component {
+        @use query = userInfo(() => ({ variables: { id: '1' } }));
+
+        <template>
+          <div data-test-id="curried-query">
+            {{#if this.query.loading}}
+              <span data-test-id="loading">Loading...</span>
+            {{else if this.query.error}}
+              <span data-test-id="error">{{this.query.error.message}}</span>
+            {{else}}
+              <span
+                data-test-id="data"
+              >{{this.query.data.user.firstName}}</span>
+            {{/if}}
+          </div>
+        </template>
+      }
+
+      await render(<template><TestComponent /></template>);
+
+      assert
+        .dom('[data-test-id="data"]')
+        .hasText('Cathaline', 'renders fetched data via curried factory');
+    });
+
+    test('createQueryResource re-renders when tracked args change', async function (assert) {
+      const state = new (class {
+        @tracked id = '1';
+      })();
+
+      class TestComponent extends Component {
+        @use query = userInfo(() => ({ variables: { id: state.id } }));
+
+        <template>
+          <div data-test-id="curried-reactive">
+            {{#if this.query.loading}}
+              <span data-test-id="loading">Loading...</span>
+            {{else}}
+              <span
+                data-test-id="name"
+              >{{this.query.data.user.firstName}}</span>
+            {{/if}}
+          </div>
+        </template>
+      }
+
+      await render(<template><TestComponent /></template>);
+
+      assert
+        .dom('[data-test-id="name"]')
+        .hasText('Cathaline', 'renders user 1');
+
+      state.id = '2';
+      await settled();
+
+      assert
+        .dom('[data-test-id="name"]')
+        .hasText('Joth', 'renders user 2 after arg change');
+    });
+
+    test('createQueryResource in template-only with (hash) helper', async function (assert) {
+      await render(
+        <template>
+          {{#let (userInfo (hash variables=(hash id="2"))) as |q|}}
+            <div data-test-id="curried-tpl">
+              {{#if q.loading}}
+                <span data-test-id="loading">Loading...</span>
+              {{else if q.error}}
+                <span data-test-id="error">{{q.error.message}}</span>
+              {{else}}
+                <span data-test-id="data">{{q.data.user.firstName}}</span>
+              {{/if}}
+            </div>
+          {{/let}}
+        </template>
+      );
+
+      assert
+        .dom('[data-test-id="data"]')
+        .hasText('Joth', 'renders user 2 via curried factory in template');
+    });
+
+    test('createMutationResource with @use', async function (assert) {
+      class TestComponent extends Component {
+        @use login = loginMutation(() => ({ variables: { username: 'john' } }));
+
+        doLogin = (): void => {
+          this.login.mutate();
+        };
+
+        <template>
+          <div data-test-id="curried-mutation">
+            <button
+              type="button"
+              data-test-id="mutate-btn"
+              {{on "click" this.doLogin}}
+            >
+              Login
+            </button>
+
+            {{#if this.login.loading}}
+              <span data-test-id="loading">Loading...</span>
+            {{else if this.login.called}}
+              <span
+                data-test-id="result"
+              >{{this.login.data.login.firstName}}</span>
+            {{/if}}
+          </div>
+        </template>
+      }
+
+      await render(<template><TestComponent /></template>);
+
+      assert
+        .dom('[data-test-id="result"]')
+        .doesNotExist('no result before mutate');
+
+      await click('[data-test-id="mutate-btn"]');
+
+      assert
+        .dom('[data-test-id="result"]')
+        .hasText('Joth', 'renders mutation result via curried factory');
+    });
+  }
+);
+
+module(
+  'Integration | Components | Curried subscriptionResource',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    let link: MockSubscriptionLink;
+
+    hooks.beforeEach(function () {
+      link = new MockSubscriptionLink();
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link,
+      });
+      setClient(this.owner, client);
+    });
+
+    test('createSubscriptionResource with @use', async function (assert) {
+      const onMessageAdded = createSubscriptionResource<
+        OnMessageAddedSubscription,
+        OnMessageAddedSubscriptionVariables
+      >(SUBSCRIPTION);
+
+      class TestComponent extends Component {
+        @use sub = onMessageAdded(() => ({
+          variables: { channel: 'general' },
+        }));
+
+        <template>
+          <div data-test-id="curried-sub">
+            {{#if this.sub.loading}}
+              <span data-test-id="loading">Loading...</span>
+            {{else}}
+              <span
+                data-test-id="message"
+              >{{this.sub.data.messageAdded.message}}</span>
+            {{/if}}
+          </div>
+        </template>
+      }
+
+      link.simulateResult({
+        result: {
+          data: {
+            messageAdded: {
+              __typename: 'Message',
+              id: '0',
+              message: 'Hello Curried',
+            },
+          },
+        },
+      });
+
+      await render(<template><TestComponent /></template>);
+
+      assert
+        .dom('[data-test-id="message"]')
+        .hasText(
+          'Hello Curried',
+          'renders subscription data via curried factory'
+        );
     });
   }
 );

--- a/test-app/tests/integration/components/resource-factory-test.gts
+++ b/test-app/tests/integration/components/resource-factory-test.gts
@@ -1,0 +1,399 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render, settled, waitUntil } from '@ember/test-helpers';
+import { hash } from '@ember/helper';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { on } from '@ember/modifier';
+import { use } from 'ember-resources';
+import { setClient, gql } from 'glimmer-apollo';
+import {
+  queryResource,
+  mutationResource,
+  subscriptionResource,
+} from 'glimmer-apollo/resource-factories';
+import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client';
+import { MockSubscriptionLink } from 'test-app/tests/helpers/mock-subscription-link';
+import type {
+  UserInfoQuery,
+  UserInfoQueryVariables,
+  LoginMutation,
+  LoginMutationVariables,
+  OnMessageAddedSubscription,
+  OnMessageAddedSubscriptionVariables,
+} from 'test-app/mocks/handlers';
+
+const USER_INFO = gql`
+  query UserInfo($id: ID!) {
+    user(id: $id) {
+      id
+      firstName
+      lastName
+    }
+  }
+`;
+
+const LOGIN = gql`
+  mutation Login($username: String!) {
+    login(username: $username) {
+      id
+      firstName
+      lastName
+    }
+  }
+`;
+
+const SUBSCRIPTION = gql`
+  subscription OnMessageAdded($channel: String!) {
+    messageAdded(channel: $channel) {
+      id
+      message
+    }
+  }
+`;
+
+module('Integration | Components | Resource Factories', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const client = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new HttpLink({ uri: '/graphql' }),
+    });
+    setClient(this.owner, client);
+  });
+
+  test('queryResource renders loading then data in template', async function (assert) {
+    class TestComponent extends Component {
+      @use query = queryResource<UserInfoQuery, UserInfoQueryVariables>(() => [
+        USER_INFO,
+        { variables: { id: '1' } },
+      ]);
+
+      <template>
+        <div data-test-id="query-test">
+          {{#if this.query.loading}}
+            <span data-test-id="loading">Loading...</span>
+          {{else if this.query.error}}
+            <span data-test-id="error">{{this.query.error.message}}</span>
+          {{else}}
+            <span data-test-id="data">{{this.query.data.user.firstName}}</span>
+          {{/if}}
+        </div>
+      </template>
+    }
+
+    await render(<template><TestComponent /></template>);
+
+    assert
+      .dom('[data-test-id="data"]')
+      .hasText('Cathaline', 'renders fetched data');
+  });
+
+  test('queryResource re-renders when tracked args change', async function (assert) {
+    const state = new (class {
+      @tracked id = '1';
+    })();
+
+    class TestComponent extends Component {
+      @use query = queryResource<UserInfoQuery, UserInfoQueryVariables>(() => [
+        USER_INFO,
+        { variables: { id: state.id } },
+      ]);
+
+      <template>
+        <div data-test-id="reactive-test">
+          {{#if this.query.loading}}
+            <span data-test-id="loading">Loading...</span>
+          {{else}}
+            <span data-test-id="name">{{this.query.data.user.firstName}}</span>
+            <span data-test-id="user-id">{{this.query.data.user.id}}</span>
+          {{/if}}
+        </div>
+      </template>
+    }
+
+    await render(<template><TestComponent /></template>);
+
+    assert.dom('[data-test-id="name"]').hasText('Cathaline', 'renders user 1');
+
+    // Change tracked arg
+    state.id = '2';
+
+    await settled();
+
+    assert
+      .dom('[data-test-id="name"]')
+      .hasText('Joth', 'renders user 2 after arg change');
+  });
+
+  test('queryResource renders error state in template', async function (assert) {
+    class TestComponent extends Component {
+      @use query = queryResource<UserInfoQuery, UserInfoQueryVariables>(() => [
+        USER_INFO,
+        { variables: { id: 'NOT_FOUND' } },
+      ]);
+
+      <template>
+        <div data-test-id="error-test">
+          {{#if this.query.loading}}
+            <span data-test-id="loading">Loading...</span>
+          {{else if this.query.error}}
+            <span data-test-id="error">{{this.query.error.message}}</span>
+          {{else}}
+            <span data-test-id="data">Has data</span>
+          {{/if}}
+        </div>
+      </template>
+    }
+
+    await render(<template><TestComponent /></template>);
+
+    assert
+      .dom('[data-test-id="error"]')
+      .hasText('User not found', 'renders error message');
+  });
+
+  test('queryResource works in template-only component with direct args', async function (assert) {
+    const options = { variables: { id: '1' } };
+
+    await render(
+      <template>
+        {{#let (queryResource USER_INFO options) as |query|}}
+          <div data-test-id="template-only">
+            {{#if query.loading}}
+              <span data-test-id="loading">Loading...</span>
+            {{else if query.error}}
+              <span data-test-id="error">{{query.error.message}}</span>
+            {{else}}
+              <span data-test-id="data">{{query.data.user.firstName}}</span>
+            {{/if}}
+          </div>
+        {{/let}}
+      </template>
+    );
+
+    assert
+      .dom('[data-test-id="data"]')
+      .hasText('Cathaline', 'renders fetched data in template-only component');
+  });
+
+  test('queryResource works in template-only component with hash helper', async function (assert) {
+    await render(
+      <template>
+        {{#let
+          (queryResource USER_INFO (hash variables=(hash id="2")))
+          as |query|
+        }}
+          <div data-test-id="hash-test">
+            {{#if query.loading}}
+              <span data-test-id="loading">Loading...</span>
+            {{else if query.error}}
+              <span data-test-id="error">{{query.error.message}}</span>
+            {{else}}
+              <span data-test-id="data">{{query.data.user.firstName}}</span>
+            {{/if}}
+          </div>
+        {{/let}}
+      </template>
+    );
+
+    assert
+      .dom('[data-test-id="data"]')
+      .hasText('Joth', 'renders user 2 data with hash helper');
+  });
+
+  test('mutationResource works in template with click handler', async function (assert) {
+    class TestComponent extends Component {
+      @use login = mutationResource<LoginMutation, LoginMutationVariables>(
+        () => [LOGIN, { variables: { username: 'john' } }]
+      );
+
+      doLogin = (): void => {
+        this.login.mutate();
+      };
+
+      <template>
+        <div data-test-id="mutation-test">
+          <button
+            type="button"
+            data-test-id="mutate-btn"
+            {{on "click" this.doLogin}}
+          >
+            Login
+          </button>
+
+          {{#if this.login.loading}}
+            <span data-test-id="loading">Loading...</span>
+          {{else if this.login.called}}
+            <span
+              data-test-id="result"
+            >{{this.login.data.login.firstName}}</span>
+          {{/if}}
+        </div>
+      </template>
+    }
+
+    await render(<template><TestComponent /></template>);
+
+    assert
+      .dom('[data-test-id="result"]')
+      .doesNotExist('no result before mutate');
+
+    await click('[data-test-id="mutate-btn"]');
+
+    assert
+      .dom('[data-test-id="result"]')
+      .hasText('Joth', 'renders mutation result');
+  });
+});
+
+module(
+  'Integration | Components | Resource Factories | subscriptionResource',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    let link: MockSubscriptionLink;
+
+    hooks.beforeEach(function () {
+      link = new MockSubscriptionLink();
+      const client = new ApolloClient({
+        cache: new InMemoryCache(),
+        link,
+      });
+      setClient(this.owner, client);
+    });
+
+    test('subscriptionResource cleans up on component teardown', async function (assert) {
+      let unsubscribed = false;
+      link.onUnsubscribe(() => {
+        unsubscribed = true;
+      });
+
+      const state = new (class {
+        @tracked show = true;
+      })();
+
+      class TestComponent extends Component {
+        @use sub = subscriptionResource<
+          OnMessageAddedSubscription,
+          OnMessageAddedSubscriptionVariables
+        >(() => [SUBSCRIPTION, { variables: { channel: 'teardown' } }]);
+
+        <template>
+          <div data-test-id="teardown-test">
+            {{#if this.sub.loading}}
+              <span data-test-id="loading">Loading...</span>
+            {{else}}
+              <span
+                data-test-id="message"
+              >{{this.sub.data.messageAdded.message}}</span>
+            {{/if}}
+          </div>
+        </template>
+      }
+
+      link.simulateResult({
+        result: {
+          data: {
+            messageAdded: { __typename: 'Message', id: '0', message: 'Hello' },
+          },
+        },
+      });
+
+      await render(
+        <template>
+          {{#if state.show}}
+            <TestComponent />
+          {{/if}}
+        </template>
+      );
+
+      assert
+        .dom('[data-test-id="message"]')
+        .hasText('Hello', 'subscription data rendered');
+      assert.false(unsubscribed, 'not yet unsubscribed');
+
+      // Tear down the component by hiding it
+      state.show = false;
+      await settled();
+
+      assert
+        .dom('[data-test-id="teardown-test"]')
+        .doesNotExist('component removed');
+      assert.true(unsubscribed, 'subscription was unsubscribed on teardown');
+    });
+
+    test('subscriptionResource renders subscription data in template', async function (assert) {
+      class TestComponent extends Component {
+        @use sub = subscriptionResource<
+          OnMessageAddedSubscription,
+          OnMessageAddedSubscriptionVariables
+        >(() => [SUBSCRIPTION, { variables: { channel: 'general' } }]);
+
+        <template>
+          <div data-test-id="sub-test">
+            {{#if this.sub.loading}}
+              <span data-test-id="loading">Loading...</span>
+            {{else if this.sub.error}}
+              <span data-test-id="error">{{this.sub.error.message}}</span>
+            {{else}}
+              <span
+                data-test-id="message"
+              >{{this.sub.data.messageAdded.message}}</span>
+            {{/if}}
+          </div>
+        </template>
+      }
+
+      // Queue first result before render. MockSubscriptionLink uses
+      // setTimeout(0), so the result is delivered during render()'s
+      // settle phase — after the subscription observer is registered
+      // but before the waitForPromise test waiter times out.
+      link.simulateResult({
+        result: {
+          data: {
+            messageAdded: {
+              __typename: 'Message',
+              id: '0',
+              message: 'Hello World',
+            },
+          },
+        },
+      });
+
+      await render(<template><TestComponent /></template>);
+
+      assert
+        .dom('[data-test-id="message"]')
+        .hasText('Hello World', 'renders first subscription message');
+
+      // Simulate a second message
+      link.simulateResult({
+        result: {
+          data: {
+            messageAdded: {
+              __typename: 'Message',
+              id: '1',
+              message: 'Second Message',
+            },
+          },
+        },
+      });
+
+      // MockSubscriptionLink uses setTimeout, so settled() is unreliable
+      // for subsequent messages. Use waitUntil to poll for the update.
+      await waitUntil(
+        () => {
+          const el = document.querySelector('[data-test-id="message"]');
+          return el?.textContent.trim() === 'Second Message';
+        },
+        { timeout: 2000 }
+      );
+
+      assert
+        .dom('[data-test-id="message"]')
+        .hasText('Second Message', 'renders updated subscription message');
+    });
+  }
+);

--- a/test-app/tests/unit/query-test.ts
+++ b/test-app/tests/unit/query-test.ts
@@ -463,4 +463,48 @@ module('useQuery', function (hooks) {
 
     sandbox.restore();
   });
+
+  test('refetch() on a skipped query permanently un-skips it', async function (assert) {
+    // In Apollo Client 4, refetch() on a standby query uses reobserve
+    // to switch fetchPolicy from 'standby' to 'network-only'. This is
+    // permanent — the query is no longer skipped after refetch().
+    const query = useQuery<UserInfoQuery, UserInfoQueryVariables>(ctx, () => [
+      USER_INFO,
+      {
+        variables: { id: '1' },
+        skip: true,
+      },
+    ]);
+
+    assert.equal(query.loading, false, 'initially not loading (skipped)');
+    assert.equal(query.data, undefined, 'no data while skipped');
+
+    query.refetch();
+    await waitUntil(() => query.data !== undefined);
+
+    assert.equal(query.loading, false, 'loaded after refetch');
+    assert.equal(query.data?.user?.id, '1', 'has data after refetch');
+
+    // Write directly to the cache — if the query is still in standby,
+    // this update would not reach our subscriber.
+    client.cache.writeQuery({
+      query: USER_INFO,
+      variables: { id: '1' },
+      data: {
+        user: {
+          __typename: 'User',
+          id: '1',
+          firstName: 'Updated',
+          lastName: 'McCoy',
+        },
+      },
+    });
+
+    await waitUntil(() => query.data?.user?.firstName === 'Updated');
+    assert.equal(
+      query.data?.user?.firstName,
+      'Updated',
+      'query receives cache updates after refetch (no longer skipped)'
+    );
+  });
 });

--- a/test-app/tests/unit/resource-factory-test.ts
+++ b/test-app/tests/unit/resource-factory-test.ts
@@ -1,0 +1,569 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { module, test } from 'qunit';
+import { destroy } from '@ember/destroyable';
+import { tracked } from '@glimmer/tracking';
+import { setClient, getClient, gql } from 'glimmer-apollo';
+import {
+  queryResource,
+  mutationResource,
+  subscriptionResource,
+} from 'glimmer-apollo/resource-factories';
+import { use } from 'ember-resources';
+import { setOwner } from '@ember/owner';
+import type Owner from '@ember/owner';
+import {
+  ApolloClient,
+  InMemoryCache,
+  type ErrorLike,
+  HttpLink,
+} from '@apollo/client';
+import {
+  type UserInfoQuery,
+  type UserInfoQueryVariables,
+  type LoginMutation,
+  type LoginMutationVariables,
+  type OnMessageAddedSubscription,
+  type OnMessageAddedSubscriptionVariables,
+} from '../../app/mocks/handlers';
+import sinon from 'sinon';
+import { waitUntil } from '@ember/test-helpers';
+import { MockSubscriptionLink } from 'test-app/tests/helpers/mock-subscription-link';
+
+const USER_INFO = gql`
+  query UserInfo($id: ID!) {
+    user(id: $id) {
+      id
+      firstName
+      lastName
+    }
+  }
+`;
+
+const LOGIN = gql`
+  mutation Login($username: String!) {
+    login(username: $username) {
+      id
+      firstName
+      lastName
+    }
+  }
+`;
+
+const SUBSCRIPTION = gql`
+  subscription OnMessageAdded($channel: String!) {
+    messageAdded(channel: $channel) {
+      id
+      message
+    }
+  }
+`;
+
+module('queryResource', function (hooks) {
+  let ctx = {};
+  // Minimal owner stub — mirrors the pattern in existing tests (query-test.ts).
+  // Only used via setOwner/getOwner for client lookup; no container/registry needed.
+  const owner: Owner = {} as Owner;
+
+  const link = new HttpLink({
+    uri: '/graphql',
+  });
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link,
+  });
+
+  hooks.beforeEach(() => {
+    ctx = {};
+    setOwner(ctx, owner);
+    setClient(ctx, client);
+  });
+
+  hooks.afterEach(() => {
+    destroy(ctx);
+  });
+
+  test('it fetches the query', async function (assert) {
+    const query = use(
+      ctx,
+      queryResource<UserInfoQuery, UserInfoQueryVariables>(() => [
+        USER_INFO,
+        { variables: { id: '1' } },
+      ])
+    );
+
+    assert.equal(query.current.loading, true);
+    assert.equal(query.current.data, undefined);
+    await query.current.settled();
+    assert.equal(query.current.loading, false);
+    assert.equal(query.current.error, undefined);
+    assert.deepEqual(query.current.data, {
+      user: {
+        __typename: 'User',
+        firstName: 'Cathaline',
+        id: '1',
+        lastName: 'McCoy',
+      },
+    });
+  });
+
+  test('it refetches the query when args change', async function (assert) {
+    class Obj {
+      @tracked id = '1';
+    }
+    const vars = new Obj();
+
+    const query = use(
+      ctx,
+      queryResource<UserInfoQuery, UserInfoQueryVariables>(() => [
+        USER_INFO,
+        { variables: { id: vars.id } },
+      ])
+    );
+
+    assert.equal(query.current.loading, true);
+    assert.equal(query.current.data, undefined);
+    await query.current.promise;
+    assert.equal(query.current.loading, false);
+    assert.equal(query.current.data?.user?.id, '1');
+
+    vars.id = '2';
+    assert.equal(query.current.loading, true);
+    assert.equal(query.current.data?.user?.id, '1');
+    await query.current.promise;
+    assert.equal(query.current.loading, false);
+    assert.equal(query.current.data?.user?.id, '2');
+  });
+
+  test('it returns error', async function (assert) {
+    const query = use(
+      ctx,
+      queryResource<UserInfoQuery, UserInfoQueryVariables>(() => [
+        USER_INFO,
+        { variables: { id: 'NOT_FOUND' } },
+      ])
+    );
+
+    assert.equal(query.current.loading, true);
+    assert.equal(query.current.data, undefined);
+    assert.equal(query.current.error, undefined);
+    await query.current.settled();
+    assert.equal(query.current.loading, false);
+    assert.equal(query.current.error?.message, 'User not found');
+    assert.equal(query.current.data, undefined);
+  });
+
+  test('it calls onComplete', async function (assert) {
+    let onCompleteCalled: unknown;
+    const query = use(
+      ctx,
+      queryResource<UserInfoQuery, UserInfoQueryVariables>(() => [
+        USER_INFO,
+        {
+          variables: { id: '2' },
+          onComplete: (data) => {
+            onCompleteCalled = data;
+          },
+        },
+      ])
+    );
+
+    assert.equal(query.current.data, undefined);
+    await query.current.settled();
+
+    const expectedData = {
+      user: {
+        __typename: 'User',
+        firstName: 'Joth',
+        id: '2',
+        lastName: 'Maverick',
+      },
+    };
+
+    assert.deepEqual(query.current.data as unknown, expectedData);
+    assert.deepEqual(onCompleteCalled, expectedData);
+  });
+
+  test('it calls onError', async function (assert) {
+    let onErrorCalled: ErrorLike;
+    const query = use(
+      ctx,
+      queryResource<UserInfoQuery, UserInfoQueryVariables>(() => [
+        USER_INFO,
+        {
+          variables: { id: 'NOT_FOUND' },
+          onError: (error) => {
+            onErrorCalled = error;
+          },
+        },
+      ])
+    );
+
+    assert.equal(query.current.error, undefined);
+    await query.current.settled();
+
+    const expectedError = 'User not found';
+    assert.equal(query.current.error?.message, expectedError);
+    assert.equal(onErrorCalled!.message, expectedError);
+  });
+
+  test('it does not trigger query update if args references change but values are the same', async function (assert) {
+    class Obj {
+      @tracked id = '1';
+    }
+    const vars = new Obj();
+    const sandbox = sinon.createSandbox();
+    const client = getClient(ctx);
+
+    const watchQuery = sandbox.spy(client, 'watchQuery');
+    const query = use(
+      ctx,
+      queryResource<UserInfoQuery, UserInfoQueryVariables>(() => [
+        USER_INFO,
+        { variables: { id: vars.id } },
+      ])
+    );
+
+    assert.equal(query.current.data, undefined);
+    await query.current.settled();
+
+    vars.id = '1';
+    await query.current.settled();
+
+    assert.ok(watchQuery.calledOnce);
+
+    sandbox.restore();
+  });
+
+  test('it fetches the query with direct args (non-thunk)', async function (assert) {
+    const query = use(
+      ctx,
+      queryResource<UserInfoQuery, UserInfoQueryVariables>(USER_INFO, {
+        variables: { id: '1' },
+      })
+    );
+
+    assert.equal(query.current.loading, true);
+    await query.current.settled();
+    assert.equal(query.current.loading, false);
+    assert.equal(query.current.error, undefined);
+    assert.deepEqual(query.current.data, {
+      user: {
+        __typename: 'User',
+        firstName: 'Cathaline',
+        id: '1',
+        lastName: 'McCoy',
+      },
+    });
+  });
+
+  test('it uses correct client based on clientId option', async function (assert) {
+    class Obj {
+      @tracked id = '1';
+    }
+    const vars = new Obj();
+    const sandbox = sinon.createSandbox();
+    const defaultClient = getClient(ctx);
+    const customClient = new ApolloClient({
+      cache: new InMemoryCache(),
+      link: new HttpLink({
+        uri: '/graphql',
+      }),
+    });
+    setClient(ctx, customClient, 'custom-client');
+
+    const defaultClientWatchQuery = sandbox.spy(defaultClient, 'watchQuery');
+    const customClientWatchQuery = sandbox.spy(customClient, 'watchQuery');
+
+    const query = use(
+      ctx,
+      queryResource<UserInfoQuery, UserInfoQueryVariables>(() => [
+        USER_INFO,
+        {
+          variables: { id: vars.id },
+          clientId: 'custom-client',
+        },
+      ])
+    );
+
+    await query.current.settled();
+    assert.ok(
+      customClientWatchQuery.calledOnce,
+      'custom client should be used'
+    );
+    assert.ok(
+      defaultClientWatchQuery.notCalled,
+      'default client should not be used'
+    );
+
+    sandbox.restore();
+  });
+});
+
+module('mutationResource', function (hooks) {
+  let ctx = {};
+  // Minimal owner stub — mirrors the pattern in existing tests (query-test.ts).
+  // Only used via setOwner/getOwner for client lookup; no container/registry needed.
+  const owner: Owner = {} as Owner;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new HttpLink({
+      uri: '/graphql',
+    }),
+  });
+
+  hooks.beforeEach(() => {
+    ctx = {};
+    setOwner(ctx, owner);
+    setClient(ctx, client);
+  });
+
+  hooks.afterEach(() => {
+    destroy(ctx);
+  });
+
+  test('it executes the mutation', async function (assert) {
+    const mutation = use(
+      ctx,
+      mutationResource<LoginMutation, LoginMutationVariables>(() => [
+        LOGIN,
+        { variables: { username: 'john' } },
+      ])
+    );
+
+    assert.equal(mutation.current.loading, false);
+    assert.equal(mutation.current.called, false);
+    assert.equal(mutation.current.data, undefined);
+
+    mutation.current.mutate();
+    assert.equal(mutation.current.loading, true);
+    await mutation.current.settled();
+
+    assert.equal(mutation.current.loading, false);
+    assert.equal(mutation.current.called, true);
+    assert.equal(mutation.current.error, undefined);
+    assert.deepEqual(mutation.current.data, {
+      login: {
+        __typename: 'User',
+        firstName: 'Joth',
+        id: '2',
+        lastName: 'Maverick',
+      },
+    });
+  });
+
+  test('it executes the mutation with direct args (non-thunk)', async function (assert) {
+    const mutation = use(
+      ctx,
+      mutationResource<LoginMutation, LoginMutationVariables>(LOGIN, {
+        variables: { username: 'john' },
+      })
+    );
+
+    assert.equal(mutation.current.loading, false);
+    assert.equal(mutation.current.called, false);
+
+    mutation.current.mutate();
+    await mutation.current.settled();
+
+    assert.equal(mutation.current.loading, false);
+    assert.equal(mutation.current.called, true);
+    assert.deepEqual(mutation.current.data, {
+      login: {
+        __typename: 'User',
+        firstName: 'Joth',
+        id: '2',
+        lastName: 'Maverick',
+      },
+    });
+  });
+
+  test('it uses variables passed into mutate', function (assert) {
+    const sandbox = sinon.createSandbox();
+    const client = getClient(ctx);
+
+    const mutate = sandbox.spy(client, 'mutate');
+    const mutation = use(
+      ctx,
+      mutationResource<LoginMutation, LoginMutationVariables>(() => [
+        LOGIN,
+        { variables: { username: 'non-existing' } },
+      ])
+    );
+
+    mutation.current.mutate({ username: 'john' });
+
+    assert.ok(mutate.called);
+    assert.deepEqual(mutate.args[0]![0].variables, { username: 'john' });
+
+    sandbox.restore();
+  });
+
+  test('it merges variables passed into mutate', function (assert) {
+    const sandbox = sinon.createSandbox();
+    const client = getClient(ctx);
+
+    const mutate = sandbox.spy(client, 'mutate');
+    const mutation = use(
+      ctx,
+      mutationResource<LoginMutation, LoginMutationVariables>(() => [
+        LOGIN,
+        { variables: { username: 'non-existing' } },
+      ])
+    );
+
+    mutation.current.mutate({ username: 'john', isCool: true } as never);
+
+    assert.ok(mutate.called);
+    assert.deepEqual(mutate.args[0]![0].variables, {
+      isCool: true,
+      username: 'john',
+    });
+
+    sandbox.restore();
+  });
+});
+
+module('subscriptionResource', function (hooks) {
+  const results = ['Hey There!', 'Hello', 'How are you?'].map(
+    (message, id) => ({
+      result: {
+        data: {
+          messageAdded: { __typename: 'Message', id: id.toString(), message },
+        },
+      },
+    })
+  );
+
+  let ctx = {};
+  // Minimal owner stub — mirrors the pattern in existing tests (query-test.ts).
+  // Only used via setOwner/getOwner for client lookup; no container/registry needed.
+  const owner: Owner = {} as Owner;
+  // Create a fresh link per test to avoid stale observer accumulation.
+  // Unlike useSubscription (which uses invokeHelper for proper destroyable
+  // cleanup), resource factories via ember-resources' use() may not fire
+  // on.cleanup synchronously in non-rendering unit test contexts.
+  let link: MockSubscriptionLink;
+
+  hooks.beforeEach(() => {
+    link = new MockSubscriptionLink();
+    ctx = {};
+    setOwner(ctx, owner);
+    setClient(
+      ctx,
+      new ApolloClient({
+        cache: new InMemoryCache(),
+        link,
+      })
+    );
+  });
+
+  hooks.afterEach(() => {
+    destroy(ctx);
+  });
+
+  test('it fetches the subscription', async function (assert) {
+    link.simulateResult(results[0]!);
+
+    const sub = use(
+      ctx,
+      subscriptionResource<
+        OnMessageAddedSubscription,
+        OnMessageAddedSubscriptionVariables
+      >(() => [SUBSCRIPTION, { variables: { channel: '1' } }])
+    );
+
+    assert.equal(sub.current.loading, true);
+    assert.equal(sub.current.data, undefined);
+    await sub.current.settled();
+    assert.equal(sub.current.loading, false);
+    assert.equal(sub.current.error, undefined);
+    assert.deepEqual(sub.current.data, {
+      messageAdded: {
+        __typename: 'Message',
+        id: '0',
+        message: 'Hey There!',
+      },
+    });
+
+    link.simulateResult(results[1]!);
+
+    await waitUntil(
+      function () {
+        return sub.current.data?.messageAdded?.id == '1';
+      },
+      { timeout: 200 }
+    );
+
+    assert.deepEqual(sub.current.data, {
+      messageAdded: {
+        __typename: 'Message',
+        id: '1',
+        message: 'Hello',
+      },
+    });
+  });
+
+  test('it fetches the subscription with direct args (non-thunk)', async function (assert) {
+    link.simulateResult(results[0]!);
+
+    const sub = use(
+      ctx,
+      subscriptionResource<
+        OnMessageAddedSubscription,
+        OnMessageAddedSubscriptionVariables
+      >(SUBSCRIPTION, { variables: { channel: '1' } })
+    );
+
+    assert.equal(sub.current.loading, true);
+    await sub.current.settled();
+    assert.equal(sub.current.loading, false);
+    assert.equal(sub.current.error, undefined);
+    assert.deepEqual(sub.current.data, {
+      messageAdded: {
+        __typename: 'Message',
+        id: '0',
+        message: 'Hey There!',
+      },
+    });
+  });
+
+  test('it re-subscribes when tracked args change', async function (assert) {
+    link.simulateResult(results[0]!);
+
+    class Obj {
+      @tracked channel = '1';
+    }
+    const vars = new Obj();
+
+    const sub = use(
+      ctx,
+      subscriptionResource<
+        OnMessageAddedSubscription,
+        OnMessageAddedSubscriptionVariables
+      >(() => [SUBSCRIPTION, { variables: { channel: vars.channel } }])
+    );
+
+    assert.equal(sub.current.loading, true);
+    assert.equal(sub.current.data, undefined);
+    await sub.current.promise;
+    assert.equal(sub.current.loading, false);
+    assert.equal(sub.current.data?.messageAdded?.id, '0');
+
+    // Change tracked arg — should trigger re-subscribe
+    vars.channel = '2';
+    assert.equal(sub.current.loading, true);
+    assert.equal(sub.current.data?.messageAdded?.id, '0');
+
+    link.simulateResult(results[1]!);
+
+    await sub.current.promise;
+    assert.equal(sub.current.loading, false);
+    assert.equal(sub.current.data?.messageAdded?.id, '1');
+  });
+
+  // Note: destroy/cleanup test for subscriptionResource is in the
+  // integration test suite where the rendering lifecycle properly
+  // manages ember-resources cleanup via the destroyable tree.
+});

--- a/test-app/tests/unit/resource-factory-test.ts
+++ b/test-app/tests/unit/resource-factory-test.ts
@@ -7,6 +7,9 @@ import {
   queryResource,
   mutationResource,
   subscriptionResource,
+  createQueryResource,
+  createMutationResource,
+  createSubscriptionResource,
 } from 'glimmer-apollo/resource-factories';
 import { use } from 'ember-resources';
 import { setOwner } from '@ember/owner';
@@ -235,28 +238,6 @@ module('queryResource', function (hooks) {
     sandbox.restore();
   });
 
-  test('it fetches the query with direct args (non-thunk)', async function (assert) {
-    const query = use(
-      ctx,
-      queryResource<UserInfoQuery, UserInfoQueryVariables>(USER_INFO, {
-        variables: { id: '1' },
-      })
-    );
-
-    assert.equal(query.current.loading, true);
-    await query.current.settled();
-    assert.equal(query.current.loading, false);
-    assert.equal(query.current.error, undefined);
-    assert.deepEqual(query.current.data, {
-      user: {
-        __typename: 'User',
-        firstName: 'Cathaline',
-        id: '1',
-        lastName: 'McCoy',
-      },
-    });
-  });
-
   test('it uses correct client based on clientId option', async function (assert) {
     class Obj {
       @tracked id = '1';
@@ -343,32 +324,6 @@ module('mutationResource', function (hooks) {
     assert.equal(mutation.current.loading, false);
     assert.equal(mutation.current.called, true);
     assert.equal(mutation.current.error, undefined);
-    assert.deepEqual(mutation.current.data, {
-      login: {
-        __typename: 'User',
-        firstName: 'Joth',
-        id: '2',
-        lastName: 'Maverick',
-      },
-    });
-  });
-
-  test('it executes the mutation with direct args (non-thunk)', async function (assert) {
-    const mutation = use(
-      ctx,
-      mutationResource<LoginMutation, LoginMutationVariables>(LOGIN, {
-        variables: { username: 'john' },
-      })
-    );
-
-    assert.equal(mutation.current.loading, false);
-    assert.equal(mutation.current.called, false);
-
-    mutation.current.mutate();
-    await mutation.current.settled();
-
-    assert.equal(mutation.current.loading, false);
-    assert.equal(mutation.current.called, true);
     assert.deepEqual(mutation.current.data, {
       login: {
         __typename: 'User',
@@ -505,30 +460,6 @@ module('subscriptionResource', function (hooks) {
     });
   });
 
-  test('it fetches the subscription with direct args (non-thunk)', async function (assert) {
-    link.simulateResult(results[0]!);
-
-    const sub = use(
-      ctx,
-      subscriptionResource<
-        OnMessageAddedSubscription,
-        OnMessageAddedSubscriptionVariables
-      >(SUBSCRIPTION, { variables: { channel: '1' } })
-    );
-
-    assert.equal(sub.current.loading, true);
-    await sub.current.settled();
-    assert.equal(sub.current.loading, false);
-    assert.equal(sub.current.error, undefined);
-    assert.deepEqual(sub.current.data, {
-      messageAdded: {
-        __typename: 'Message',
-        id: '0',
-        message: 'Hey There!',
-      },
-    });
-  });
-
   test('it re-subscribes when tracked args change', async function (assert) {
     link.simulateResult(results[0]!);
 
@@ -566,4 +497,203 @@ module('subscriptionResource', function (hooks) {
   // Note: destroy/cleanup test for subscriptionResource is in the
   // integration test suite where the rendering lifecycle properly
   // manages ember-resources cleanup via the destroyable tree.
+});
+
+// Curried resource factory tests
+
+const userInfo = createQueryResource<UserInfoQuery, UserInfoQueryVariables>(
+  USER_INFO
+);
+
+module('createQueryResource', function (hooks) {
+  let ctx = {};
+  const owner: Owner = {} as Owner;
+
+  const link = new HttpLink({
+    uri: '/graphql',
+  });
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link,
+  });
+
+  hooks.beforeEach(() => {
+    ctx = {};
+    setOwner(ctx, owner);
+    setClient(ctx, client);
+  });
+
+  hooks.afterEach(() => {
+    destroy(ctx);
+  });
+
+  test('it fetches the query with thunk options', async function (assert) {
+    const query = use(
+      ctx,
+      userInfo(() => ({ variables: { id: '1' } }))
+    );
+
+    assert.equal(query.current.loading, true);
+    await query.current.settled();
+    assert.equal(query.current.loading, false);
+    assert.equal(query.current.error, undefined);
+    assert.deepEqual(query.current.data, {
+      user: {
+        __typename: 'User',
+        firstName: 'Cathaline',
+        id: '1',
+        lastName: 'McCoy',
+      },
+    });
+  });
+
+  test('it fetches the query with direct options', async function (assert) {
+    const query = use(
+      ctx,
+      userInfo({ variables: { id: '2' } })
+    );
+
+    assert.equal(query.current.loading, true);
+    await query.current.settled();
+    assert.equal(query.current.loading, false);
+    assert.deepEqual(query.current.data, {
+      user: {
+        __typename: 'User',
+        firstName: 'Joth',
+        id: '2',
+        lastName: 'Maverick',
+      },
+    });
+  });
+
+  test('it re-fetches when tracked args change', async function (assert) {
+    class Obj {
+      @tracked id = '1';
+    }
+    const vars = new Obj();
+
+    const query = use(
+      ctx,
+      userInfo(() => ({ variables: { id: vars.id } }))
+    );
+
+    assert.equal(query.current.loading, true);
+    await query.current.promise;
+    assert.equal(query.current.loading, false);
+    assert.equal(query.current.data?.user?.id, '1');
+
+    vars.id = '2';
+    assert.equal(query.current.loading, true);
+    await query.current.promise;
+    assert.equal(query.current.loading, false);
+    assert.equal(query.current.data?.user?.id, '2');
+  });
+});
+
+module('createMutationResource', function (hooks) {
+  let ctx = {};
+  const owner: Owner = {} as Owner;
+
+  const client = new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new HttpLink({ uri: '/graphql' }),
+  });
+
+  const login = createMutationResource<LoginMutation, LoginMutationVariables>(
+    LOGIN
+  );
+
+  hooks.beforeEach(() => {
+    ctx = {};
+    setOwner(ctx, owner);
+    setClient(ctx, client);
+  });
+
+  hooks.afterEach(() => {
+    destroy(ctx);
+  });
+
+  test('it executes the mutation with thunk options', async function (assert) {
+    const mutation = use(
+      ctx,
+      login(() => ({ variables: { username: 'john' } }))
+    );
+
+    assert.equal(mutation.current.loading, false);
+    assert.equal(mutation.current.called, false);
+
+    mutation.current.mutate();
+    assert.equal(mutation.current.loading, true);
+    await mutation.current.settled();
+
+    assert.equal(mutation.current.loading, false);
+    assert.equal(mutation.current.called, true);
+    assert.deepEqual(mutation.current.data, {
+      login: {
+        __typename: 'User',
+        firstName: 'Joth',
+        id: '2',
+        lastName: 'Maverick',
+      },
+    });
+  });
+});
+
+module('createSubscriptionResource', function (hooks) {
+  let ctx = {};
+  const owner: Owner = {} as Owner;
+  let link: MockSubscriptionLink;
+
+  const onMessageAdded = createSubscriptionResource<
+    OnMessageAddedSubscription,
+    OnMessageAddedSubscriptionVariables
+  >(SUBSCRIPTION);
+
+  hooks.beforeEach(() => {
+    link = new MockSubscriptionLink();
+    ctx = {};
+    setOwner(ctx, owner);
+    setClient(
+      ctx,
+      new ApolloClient({
+        cache: new InMemoryCache(),
+        link,
+      })
+    );
+  });
+
+  hooks.afterEach(() => {
+    destroy(ctx);
+  });
+
+  test('it fetches the subscription with thunk options', async function (assert) {
+    link.simulateResult({
+      result: {
+        data: {
+          messageAdded: {
+            __typename: 'Message',
+            id: '0',
+            message: 'Hey There!',
+          },
+        },
+      },
+    });
+
+    const sub = use(
+      ctx,
+      onMessageAdded(() => ({ variables: { channel: '1' } }))
+    );
+
+    assert.equal(sub.current.loading, true);
+    await sub.current.settled();
+    assert.equal(sub.current.loading, false);
+    assert.deepEqual(sub.current.data, {
+      messageAdded: {
+        __typename: 'Message',
+        id: '0',
+        message: 'Hey There!',
+      },
+    });
+  });
 });


### PR DESCRIPTION
### Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
  - Add `queryResource`, `mutationResource`, and `subscriptionResource` factory
    functions exported from `glimmer-apollo/resource-factories`
  - Enable Apollo operations in template-only components via `{{#let}}` and
    in class-based components via the `@use` decorator from `ember-resources`
  - `ember-resources` is an **optional** peer dependency — existing usage of
    `useQuery`, `useMutation`, and `useSubscription` is completely unchanged

  ### Motivation
  Today, using Apollo with glimmer-apollo requires a backing class for every
  component that fetches data. The `ember-resources` ecosystem provides a
  `resource()` / `resourceFactory()` primitive that enables reactive data
  patterns directly in templates. This PR bridges glimmer-apollo's existing
  Resource classes into that ecosystem without modifying any existing code.

  ### Design
  A single `wrapResource()` helper wraps any glimmer-apollo Resource subclass
  (`QueryResource`, `MutationResource`, `SubscriptionResource`) into an
  ember-resources `resource()`. Lifecycle (setup/update/teardown) is derived
  from the prototype, mirroring `ResourceManager.createHelper`. A `Proxy`
  entangles property access with autotracking, matching the existing
  `useResource` pattern.

  Each factory supports two calling conventions:

  | Convention | Syntax | Use case |
  |------------|--------|----------|
  | Direct args | `queryResource(QUERY, opts)` | `{{#let}}` in templates |
  | Thunk | `queryResource(() => [QUERY, opts])` | `@use` decorator |
  
### Alternative approach
Full integration with ember-resources, where QueryResource, MutationResource, and SubscriptionResource are rewritten as native resource() functions instead of wrapping the existing class-based Resources. This would give native @use support and composability (via ember-resources' use() hook) without needing the Proxy bridge layer. However, it would also change the ergonomics and APIs, maybe not even a good fit for all current glimmer-apollo-resources.

### Test plan
  - [ ] `pnpm test` passes in test-app (unit + integration)
  - [ ] Build succeeds (`pnpm build` in glimmer-apollo)
  - [ ] Verify import from `glimmer-apollo/resource-factories` resolves
  - [ ] Verify no impact when `ember-resources` is not installed (existing
        imports from `glimmer-apollo` still work)
        
        
 Cowritten by claude